### PR TITLE
Extract bibliographic metadata for notes

### DIFF
--- a/templates/lm-studio-template.md
+++ b/templates/lm-studio-template.md
@@ -36,7 +36,12 @@ tags: []
 
 ## SECTION 5: SOURCE(S) & FURTHER READING (Optional)
 
+{% if source_details %}
+*   {{ source_details.author }}{% if source_details.date %} ({{ source_details.date }}){% endif %}. *{{ source_details.title }}*. {{ source_details.publisher }}{% if source_details.isbn %}. ISBN: {{ source_details.isbn }}{% endif %}.
+{% else %}
 *   Author, A. (Year). *Title of Book/Article*. Publisher.
+{% endif %}
+
 *   [Link to relevant website or resource]
 
 ---


### PR DESCRIPTION
## Summary
- parse Trello card descriptions for book metadata when the Title/Author/Publisher/Date/IBSN section is present
- render captured source details into Section 5 of the Obsidian note template

## Testing
- python trello_to_markdown.py 'r6MMYk8s - reading-list-a.json' -o /tmp/notes

------
https://chatgpt.com/codex/tasks/task_e_68cb85d220b88329872bcd59e3d4c92a